### PR TITLE
Support Robot Framework 3.2

### DIFF
--- a/pre_commit_robotframework_tidy/rf_tidy.py
+++ b/pre_commit_robotframework_tidy/rf_tidy.py
@@ -16,8 +16,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     tidier = Tidy(use_pipes=args.use_pipes,
-                  space_count=args.space_count,
-                  format='robot')
+                  space_count=args.space_count)
     for filename in args.filenames:
         try:
             tidier.inplace(filename)


### PR DESCRIPTION
Format argument is not supported in RF 3.2
Fixes this issue: https://github.com/guykisel/pre-commit-robotframework-tidy/issues/4