### PR TITLE
Fix the hook for robot framework 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-install_requires = ['robotframework']
+install_requires = ['robotframework<5']
 if sys.version_info < (2, 7):
     install_requires.append('argparse')
 


### PR DESCRIPTION
Built-in tydy tool has been removed from robotframework 5.0 and there is a separate tool `robotidy` available, which supports pre-commit hooks natively. For this reason, set an upper bound for robotframework in dependencies
Error:
```
Traceback (most recent call last): 
File "/home/runner/.cache/pre-commit/repoq2ln0w49/py_env-python3.10/bin/python-robotframework-tidy", line 5, in <module> 
from pre_commit_robotframework_tidy.rf_tidy import main 
File "/home/runner/.cache/pre-commit/repoq2ln0w49/py_env-python3.10/lib/python3.10/site-packages/pre_commit_robotframework_tidy/rf_tidy.py", line 6, in <module> 
from robot.tidy import Tidy 
ModuleNotFoundError: No module named 'robot.tidy' 
```